### PR TITLE
Connect politician tracker to live disclosure feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# BPVPoliticiantrading
+# BPV Politician Trading
+
+A lightweight web app that surfaces recent stock trades reported by members of the United States Congress. The interface pulls the latest periodic transaction reports (PTRs) that senators and representatives must file under the STOCK Act so you can quickly review who bought or sold specific securities.
+
+## Getting started
+
+1. Open `index.html` in any modern browser. No build tooling or backend setup is required.
+2. The page will immediately request the newest PTR filings from the U.S. Senate and U.S. House disclosure feeds. Depending on your connection this may take a few seconds.
+3. Use the controls in the hero banner to refine what you see:
+   - **Search politician** – match on name, state, party, ticker, or asset description.
+   - **Transaction type** – toggle between buys, sells, or both.
+   - **Chamber** – focus on senators, representatives, or both at once.
+   - **Activity window** – limit the table to trades filed within the last 30/90/365 days or view all available records.
+
+> Tip: The table shows the first 500 matches for performance. Narrow the filters to drill into a specific member or company if you expect a large result set.
+
+## Data pipeline
+
+- **Senate PTRs** – Pulled from the public S3 mirror of the Senate financial disclosure system, which republishes Form PTR filings sourced from [efdsearch.senate.gov](https://efdsearch.senate.gov/). The script attempts the current and previous filing years.
+- **House PTRs** – Pulled from the House Stock Watcher dataset which mirrors official filings made to the [Clerk of the House](https://disclosures-clerk.house.gov/).
+
+Because the SEC and congressional disclosure portals require a real browser user agent, direct `curl` requests from locked-down environments may fail. The production app runs entirely in the browser and automatically includes the headers those services expect.
+
+## Tech stack
+
+- Vanilla HTML, CSS, and JavaScript (no frameworks or build steps)
+- Responsive, dark-themed layout optimised for desktop and tablet
+- Client-side filtering, summarisation, and deduplication of disclosure data

--- a/app.js
+++ b/app.js
@@ -1,0 +1,593 @@
+const MS_PER_DAY = 86_400_000;
+const MAX_RENDERED_ROWS = 500;
+const WINDOW_LABELS = {
+  '30': 'reported in the last 30 days',
+  '90': 'reported in the last 90 days',
+  '365': 'reported in the last 12 months',
+  all: 'across all available disclosures',
+};
+
+const statusEl = document.getElementById('status');
+const tableContainer = document.querySelector('.table-container');
+const resultsBody = document.getElementById('resultsBody');
+const rowTemplate = document.getElementById('rowTemplate');
+const summaryEl = document.getElementById('summary');
+const summaryCountEl = summaryEl.querySelector('[data-count]');
+const summaryWindowEl = summaryEl.querySelector('[data-window]');
+const summarySourcesEl = summaryEl.querySelector('[data-sources]');
+const summaryUpdatedEl = summaryEl.querySelector('[data-updated]');
+const summaryNoteEl = summaryEl.querySelector('[data-note]');
+const searchInput = document.getElementById('searchInput');
+const typeFilter = document.getElementById('typeFilter');
+const chamberFilter = document.getElementById('chamberFilter');
+const windowFilter = document.getElementById('windowFilter');
+
+let transactions = [];
+let filteredTransactions = [];
+let loadedSources = [];
+let latestDisclosureMs = 0;
+
+const currentYear = new Date().getFullYear();
+const senateYears = [currentYear, currentYear - 1];
+
+const SOURCES = [
+  {
+    id: 'senate',
+    chamber: 'senate',
+    chamberLabel: 'Senate',
+    label: 'U.S. Senate periodic transaction reports',
+    urls: senateYears.map(
+      (year) =>
+        `https://senate-stock-watcher-data.s3-us-west-2.amazonaws.com/transaction_report_for_${year}.json`
+    ),
+    normalize: (entry, source) => {
+      if (!entry) return null;
+
+      const name = [entry.first_name, entry.last_name]
+        .filter(Boolean)
+        .map((part) => String(part).trim())
+        .filter(Boolean)
+        .join(' ');
+
+      const { code: transaction, label: transactionLabel } = getTransactionKind(
+        entry.type || entry.transaction || entry.transaction_type
+      );
+
+      const ticker = (entry.ticker || entry.symbol || '').trim();
+      const assetName = (entry.asset_name || entry.asset_description || '').trim();
+      const amountRaw = entry.amount || entry.amount_range || entry.capital_gains || '';
+      const tradeDate = parseDate(entry.transaction_date || entry.transactionDate);
+      const disclosureDate = parseDate(
+        entry.filing_date || entry.disclosure_date || entry.reported_date
+      );
+
+      const uniqueKey =
+        entry.ptr_link ||
+        `${name || 'unknown'}-${ticker || 'na'}-${entry.transaction_date || ''}-$${
+          entry.amount || ''
+        }-${transactionLabel}`;
+
+      return {
+        id: `${source.id}-${uniqueKey}`,
+        uniqueKey,
+        representative: name || 'Unknown',
+        state: entry.state || entry.state_cd || '',
+        party: entry.party || '',
+        owner: entry.owner || '',
+        chamber: source.chamber,
+        chamberLabel: source.chamberLabel,
+        transaction,
+        transactionLabel,
+        ticker,
+        assetName,
+        amountDisplay: formatAmount(amountRaw),
+        tradeDate,
+        tradeDateMs: tradeDate ? tradeDate.getTime() : null,
+        tradeDateDisplay: formatDate(tradeDate),
+        disclosureDate,
+        disclosureDateMs: disclosureDate ? disclosureDate.getTime() : null,
+        disclosureDateDisplay: formatDate(disclosureDate),
+        sourceLabel: source.label,
+        sourceUrl: entry.ptr_link || entry.source_url || '',
+        searchText: buildSearchText({
+          representative: name,
+          ticker,
+          assetName,
+          state: entry.state,
+          party: entry.party,
+          owner: entry.owner,
+        }),
+      };
+    },
+  },
+  {
+    id: 'house',
+    chamber: 'house',
+    chamberLabel: 'House',
+    label: 'U.S. House periodic transaction reports',
+    urls: [
+      'https://house-stock-watcher-data.s3-us-west-2.amazonaws.com/data/all_transactions.json',
+    ],
+    normalize: (entry, source) => {
+      if (!entry) return null;
+
+      const name = entry.representative ||
+        [entry.first_name, entry.last_name].filter(Boolean).join(' ');
+
+      const { code: transaction, label: transactionLabel } = getTransactionKind(
+        entry.transaction || entry.transaction_type || entry.type
+      );
+
+      const ticker = (entry.ticker || entry.symbol || '').trim();
+      const assetName =
+        (entry.asset_description || entry.asset_name || entry.company || '').trim();
+      const amountRaw =
+        entry.amount || entry.amount_range || entry.capital_gains || entry.amount_description;
+      const tradeDate = parseDate(
+        entry.transaction_date || entry.transactionDate || entry.date_of_transaction
+      );
+      const disclosureDate = parseDate(
+        entry.disclosure_date || entry.report_date || entry.reported_date || entry.date_filed
+      );
+
+      const uniqueKey =
+        entry.tx_id ||
+        entry.report_id ||
+        `${name || 'unknown'}-${entry.district || entry.state || ''}-${
+          ticker || assetName
+        }-${tradeDate ? tradeDate.toISOString() : ''}-${transactionLabel}`;
+
+      return {
+        id: `${source.id}-${uniqueKey}`,
+        uniqueKey,
+        representative: (name || 'Unknown').trim(),
+        state: entry.state || entry.district || '',
+        party: entry.party || '',
+        owner: entry.owner || '',
+        chamber: source.chamber,
+        chamberLabel: source.chamberLabel,
+        transaction,
+        transactionLabel,
+        ticker,
+        assetName,
+        amountDisplay: formatAmount(amountRaw),
+        tradeDate,
+        tradeDateMs: tradeDate ? tradeDate.getTime() : null,
+        tradeDateDisplay: formatDate(tradeDate),
+        disclosureDate,
+        disclosureDateMs: disclosureDate ? disclosureDate.getTime() : null,
+        disclosureDateDisplay: formatDate(disclosureDate),
+        sourceLabel: source.label,
+        sourceUrl:
+          entry.ptr_link || entry.report_link || entry.disclosure_url || entry.source_url || '',
+        searchText: buildSearchText({
+          representative: name,
+          ticker,
+          assetName,
+          state: entry.state || entry.district,
+          party: entry.party,
+          owner: entry.owner,
+        }),
+      };
+    },
+  },
+];
+
+const debounce = (fn, wait = 200) => {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), wait);
+  };
+};
+
+function parseDate(rawValue) {
+  if (!rawValue) return null;
+
+  if (rawValue instanceof Date) {
+    return Number.isNaN(rawValue.getTime()) ? null : rawValue;
+  }
+
+  if (typeof rawValue === 'number') {
+    const date = new Date(rawValue);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const value = String(rawValue).trim();
+  if (!value) return null;
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+
+  const slashMatch = value.match(/^(\d{1,2})[\/](\d{1,2})[\/](\d{2,4})$/);
+  if (slashMatch) {
+    let [, month, day, year] = slashMatch;
+    if (year.length === 2) {
+      year = `20${year}`;
+    }
+    const isoCandidate = `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(
+      2,
+      '0'
+    )}`;
+    const isoDate = new Date(isoCandidate);
+    if (!Number.isNaN(isoDate.getTime())) {
+      return isoDate;
+    }
+  }
+
+  const dashMatch = value.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (dashMatch) {
+    const [, year, month, day] = dashMatch;
+    const isoDate = new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+    if (!Number.isNaN(isoDate.getTime())) {
+      return isoDate;
+    }
+  }
+
+  return null;
+}
+
+function formatDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatAmount(rawAmount) {
+  if (rawAmount === null || rawAmount === undefined) {
+    return 'Unknown';
+  }
+
+  const normalized = String(rawAmount).replace(/[$,]/g, '').trim();
+  if (!normalized) {
+    return 'Unknown';
+  }
+
+  if (/less than/i.test(rawAmount)) {
+    return rawAmount;
+  }
+
+  const rangeMatch = normalized.match(/(\d+)\s*-\s*(\d+)/);
+  if (rangeMatch) {
+    const [, minRaw, maxRaw] = rangeMatch;
+    const min = Number.parseInt(minRaw, 10);
+    const max = Number.parseInt(maxRaw, 10);
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      const formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+      });
+      return `${formatter.format(min)} – ${formatter.format(max)}`;
+    }
+  }
+
+  const value = Number.parseInt(normalized, 10);
+  if (Number.isFinite(value)) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  return String(rawAmount).trim();
+}
+
+function getTransactionKind(rawValue) {
+  const label = (rawValue && String(rawValue).trim()) || 'Other';
+  const lower = label.toLowerCase();
+
+  if (lower.includes('purchase') || lower.includes('buy')) {
+    return { code: 'purchase', label };
+  }
+
+  if (lower.includes('sale')) {
+    return { code: 'sale', label };
+  }
+
+  return { code: 'other', label };
+}
+
+function buildSearchText(parts = {}) {
+  return Object.values(parts)
+    .filter(Boolean)
+    .map((value) => String(value).toLowerCase())
+    .join(' ');
+}
+
+function setStatus(message, { isError = false, hidden = false, loading = false } = {}) {
+  statusEl.querySelector('.status-text').textContent = message;
+  statusEl.classList.toggle('status--error', isError);
+  statusEl.classList.toggle('status--hidden', hidden);
+  statusEl.classList.toggle('status--loading', loading);
+}
+
+function formatRelativeTime(dateMs) {
+  if (!dateMs) return 'recently';
+  const diffMs = Date.now() - dateMs;
+  if (diffMs <= 0) return 'today';
+
+  const diffDays = Math.round(diffMs / MS_PER_DAY);
+  if (diffDays <= 0) return 'today';
+  if (diffDays === 1) return '1 day ago';
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  const diffWeeks = Math.round(diffDays / 7);
+  if (diffWeeks < 8) {
+    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
+  }
+
+  const diffMonths = Math.round(diffDays / 30);
+  return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
+}
+
+function renderRows(data) {
+  if (!Array.isArray(data) || data.length === 0) {
+    resultsBody.replaceChildren();
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  data.forEach((entry) => {
+    const clone = rowTemplate.content.firstElementChild.cloneNode(true);
+
+    const nameEl = clone.querySelector('.politician-name');
+    const metaEl = clone.querySelector('.politician-meta');
+    const chamberEl = clone.querySelector('.chamber');
+    const transactionEl = clone.querySelector('.transaction');
+    const tickerEl = clone.querySelector('.asset .ticker');
+    const assetNameEl = clone.querySelector('.asset .asset-name');
+    const amountEl = clone.querySelector('.amount');
+    const tradeDateEl = clone.querySelector('.trade-date');
+    const filedDateEl = clone.querySelector('.filed-date');
+    const linkEl = clone.querySelector('.filed-link');
+
+    nameEl.textContent = entry.representative;
+
+    const metaParts = [];
+    if (entry.state) {
+      metaParts.push(String(entry.state).toUpperCase());
+    }
+    if (entry.party) {
+      metaParts.push(String(entry.party).toUpperCase());
+    }
+    if (entry.owner) {
+      const ownerText = String(entry.owner)
+        .toLowerCase()
+        .replace(/\b\w/g, (match) => match.toUpperCase());
+      metaParts.push(ownerText);
+    }
+    metaEl.textContent = metaParts.join(' • ');
+
+    chamberEl.textContent = entry.chamberLabel;
+    transactionEl.textContent = entry.transactionLabel;
+    transactionEl.classList.toggle('transaction--sale', entry.transaction === 'sale');
+
+    tickerEl.textContent = entry.ticker || '—';
+    assetNameEl.textContent = entry.assetName || '—';
+    amountEl.textContent = entry.amountDisplay || 'Unknown';
+    tradeDateEl.textContent = entry.tradeDateDisplay;
+    filedDateEl.textContent = entry.disclosureDateDisplay;
+
+    if (entry.sourceUrl) {
+      linkEl.href = entry.sourceUrl;
+      linkEl.hidden = false;
+    } else {
+      linkEl.hidden = true;
+    }
+
+    fragment.appendChild(clone);
+  });
+
+  resultsBody.replaceChildren(fragment);
+}
+
+function updateSummary(data) {
+  if (!transactions.length) {
+    summaryEl.hidden = true;
+    return;
+  }
+
+  summaryEl.hidden = false;
+  summaryCountEl.textContent = (data.length || 0).toLocaleString('en-US');
+  summaryWindowEl.textContent = WINDOW_LABELS[windowFilter.value] || 'reported recently';
+  summarySourcesEl.textContent = loadedSources.length
+    ? loadedSources.join(', ')
+    : 'No data sources available';
+  summaryUpdatedEl.textContent = formatRelativeTime(latestDisclosureMs);
+
+  if (data.length > MAX_RENDERED_ROWS) {
+    summaryNoteEl.hidden = false;
+    summaryNoteEl.textContent = `Showing first ${MAX_RENDERED_ROWS.toLocaleString('en-US')} of ${data
+      .length.toLocaleString('en-US')} matches.`;
+  } else {
+    summaryNoteEl.hidden = true;
+    summaryNoteEl.textContent = '';
+  }
+}
+
+function applyFilters() {
+  if (!transactions.length) {
+    return [];
+  }
+
+  const searchTerm = searchInput.value.trim().toLowerCase();
+  const selectedType = typeFilter.value;
+  const selectedChamber = chamberFilter.value;
+  const windowValue = windowFilter.value;
+  const nowMs = Date.now();
+
+  filteredTransactions = transactions.filter((entry) => {
+    const matchesSearch = !searchTerm || entry.searchText.includes(searchTerm);
+    const matchesType =
+      selectedType === 'all' ? true : entry.transaction === selectedType;
+    const matchesChamber =
+      selectedChamber === 'all' ? true : entry.chamber === selectedChamber;
+
+    let matchesWindow = true;
+    if (windowValue !== 'all') {
+      const limitDays = Number.parseInt(windowValue, 10);
+      if (Number.isFinite(limitDays)) {
+        const reference = entry.tradeDateMs ?? entry.disclosureDateMs;
+        if (!reference) {
+          matchesWindow = false;
+        } else {
+          const diffDays = (nowMs - reference) / MS_PER_DAY;
+          matchesWindow = diffDays <= limitDays;
+        }
+      }
+    }
+
+    return matchesSearch && matchesType && matchesChamber && matchesWindow;
+  });
+
+  return filteredTransactions;
+}
+
+function filterTransactions() {
+  if (!transactions.length) {
+    setStatus('Loading transactions...', { loading: true });
+    summaryEl.hidden = true;
+    tableContainer.hidden = true;
+    return;
+  }
+
+  const results = applyFilters();
+  updateSummary(results);
+
+  if (results.length === 0) {
+    tableContainer.hidden = true;
+    renderRows([]);
+    setStatus('No transactions matched your filters.', { isError: true });
+    return;
+  }
+
+  const rowsToRender = results.slice(0, MAX_RENDERED_ROWS);
+
+  tableContainer.hidden = false;
+  setStatus('', { hidden: true });
+  renderRows(rowsToRender);
+}
+
+async function fetchSource(source) {
+  const entries = [];
+  const successfulUrls = [];
+
+  await Promise.all(
+    source.urls.map(async (url) => {
+      try {
+        const response = await fetch(url, {
+          cache: 'no-store',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to download ${url} (${response.status})`);
+        }
+
+        const data = await response.json();
+        if (!Array.isArray(data)) {
+          return;
+        }
+
+        data.forEach((item) => {
+          const normalized = source.normalize(item, source);
+          if (normalized) {
+            entries.push(normalized);
+          }
+        });
+
+        successfulUrls.push(url);
+      } catch (error) {
+        console.warn(`[${source.id}]`, error);
+      }
+    })
+  );
+
+  return {
+    id: source.id,
+    label: source.label,
+    entries,
+    successfulUrls,
+  };
+}
+
+async function loadTransactions() {
+  setStatus('Loading transactions from official disclosures...', { loading: true });
+  summaryEl.hidden = true;
+  tableContainer.hidden = true;
+  loadedSources = [];
+
+  try {
+    const results = await Promise.all(SOURCES.map((source) => fetchSource(source)));
+    const combined = [];
+    const seenKeys = new Set();
+
+    results.forEach((result, index) => {
+      if (result.entries.length > 0) {
+        loadedSources.push(SOURCES[index].label);
+      }
+
+      result.entries.forEach((entry) => {
+        const key = entry.uniqueKey || entry.id;
+        if (key && seenKeys.has(key)) {
+          return;
+        }
+        if (key) {
+          seenKeys.add(key);
+        }
+        combined.push(entry);
+      });
+    });
+
+    transactions = combined.filter((entry) =>
+      entry.transaction === 'purchase' || entry.transaction === 'sale'
+    );
+
+    if (!transactions.length) {
+      throw new Error('No transactions were loaded from the disclosure feeds.');
+    }
+
+    transactions.sort((a, b) => {
+      const dateA = a.tradeDateMs ?? a.disclosureDateMs ?? 0;
+      const dateB = b.tradeDateMs ?? b.disclosureDateMs ?? 0;
+      return dateB - dateA;
+    });
+
+    const MAX_TRACKED = 1500;
+    if (transactions.length > MAX_TRACKED) {
+      transactions = transactions.slice(0, MAX_TRACKED);
+    }
+
+    latestDisclosureMs = transactions.reduce((latest, entry) => {
+      const candidate = entry.disclosureDateMs ?? entry.tradeDateMs ?? 0;
+      return candidate > latest ? candidate : latest;
+    }, 0);
+
+    loadedSources = Array.from(new Set(loadedSources));
+
+    filterTransactions();
+  } catch (error) {
+    console.error(error);
+    setStatus(
+      'Unable to load the latest disclosures right now. Please refresh or try again later.',
+      { isError: true }
+    );
+  }
+}
+
+searchInput.addEventListener('input', debounce(filterTransactions, 150));
+typeFilter.addEventListener('change', filterTransactions);
+chamberFilter.addEventListener('change', filterTransactions);
+windowFilter.addEventListener('change', filterTransactions);
+
+loadTransactions();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Politician Stock Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-content">
+        <h1>USA Politician Stock Activity</h1>
+        <p class="subtitle">
+          Explore stock transactions reported by members of the U.S. Senate and
+          House of Representatives based on their legally required disclosures.
+          Search by name, focus on buys or sells, and narrow the activity window
+          to quickly spot fresh trades.
+        </p>
+      </div>
+      <div class="controls">
+        <label class="search-group">
+          <span class="label">Search politician</span>
+          <input
+            id="searchInput"
+            type="search"
+            placeholder="e.g. Nancy Pelosi"
+            autocomplete="off"
+          />
+        </label>
+        <label class="filter-group">
+          <span class="label">Transaction type</span>
+          <select id="typeFilter">
+            <option value="all">All</option>
+            <option value="purchase">Buy only</option>
+            <option value="sale">Sell only</option>
+          </select>
+        </label>
+        <label class="filter-group">
+          <span class="label">Chamber</span>
+          <select id="chamberFilter">
+            <option value="all">Both chambers</option>
+            <option value="senate">Senate</option>
+            <option value="house">House</option>
+          </select>
+        </label>
+        <label class="filter-group">
+          <span class="label">Activity window</span>
+          <select id="windowFilter">
+            <option value="30">Last 30 days</option>
+            <option value="90" selected>Last 90 days</option>
+            <option value="365">Last 12 months</option>
+            <option value="all">All available</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <main>
+      <section id="summary" class="summary" hidden>
+        <div>
+          <p class="summary__headline">
+            <span data-count>0</span> transactions <span data-window>reported recently</span>
+          </p>
+          <p class="summary__sources">
+            Sources: <span data-sources></span>
+          </p>
+          <p class="summary__note" data-note hidden></p>
+        </div>
+        <div class="summary__updated">
+          Updated <span data-updated>—</span>
+        </div>
+      </section>
+
+      <section id="status" class="status status--loading">
+        <span class="spinner" aria-hidden="true"></span>
+        <span class="status-text">Loading transactions...</span>
+      </section>
+
+      <section class="table-container" hidden>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Politician</th>
+              <th scope="col">Chamber</th>
+              <th scope="col">Transaction</th>
+              <th scope="col">Asset</th>
+              <th scope="col">Amount</th>
+              <th scope="col">Traded</th>
+              <th scope="col">Filed</th>
+            </tr>
+          </thead>
+          <tbody id="resultsBody"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <template id="rowTemplate">
+      <tr>
+        <td class="politician">
+          <div class="politician-name"></div>
+          <div class="politician-meta"></div>
+        </td>
+        <td class="chamber"></td>
+        <td class="transaction"></td>
+        <td class="asset">
+          <div class="ticker"></div>
+          <div class="asset-name"></div>
+        </td>
+        <td class="amount"></td>
+        <td class="trade-date"></td>
+        <td class="filed">
+          <span class="filed-date"></span>
+          <a class="filed-link" target="_blank" rel="noreferrer noopener">Report</a>
+        </td>
+      </tr>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,346 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-card: rgba(15, 23, 42, 0.75);
+  --bg-light: #f8fafc;
+  --text: #0f172a;
+  --text-light: #e2e8f0;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --border: rgba(148, 163, 184, 0.3);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, #020617);
+  color: var(--text-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem 1rem 3rem;
+}
+
+header {
+  width: min(960px, 100%);
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  color: rgba(226, 232, 240, 0.75);
+  max-width: 50ch;
+  line-height: 1.5;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.search-group {
+  flex: 2 1 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-group {
+  flex: 1 1 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+input[type='search'],
+select {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+input[type='search']:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+main {
+  width: min(960px, 100%);
+}
+
+.summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.summary__headline {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.summary__headline span[data-count] {
+  color: #bfdbfe;
+}
+
+.summary__sources {
+  margin-top: 0.25rem;
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.9rem;
+}
+
+.summary__note {
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.summary__updated {
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.status--error {
+  background: rgba(190, 18, 60, 0.18);
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.status--hidden {
+  display: none;
+}
+
+.status-text {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status:not(.status--loading) .spinner {
+  display: none;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 3px solid rgba(226, 232, 240, 0.3);
+  border-top-color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.table-container {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.5);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(15, 23, 42, 0.85);
+}
+
+th,
+td {
+  padding: 1rem 1.2rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(226, 232, 240, 0.65);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+tbody tr:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.politician {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.politician-name {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.politician-meta {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.chamber {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.transaction {
+  text-transform: capitalize;
+}
+
+.transaction::before {
+  content: '';
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  background: linear-gradient(135deg, #16a34a, #4ade80);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.transaction--sale::before {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.18);
+}
+
+.amount {
+  font-variant-numeric: tabular-nums;
+}
+
+.asset {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.asset .ticker {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.asset .asset-name {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.trade-date,
+.filed-date {
+  font-variant-numeric: tabular-nums;
+}
+
+.filed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.filed-link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.14);
+  color: #bfdbfe;
+  text-decoration: none;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 0.2s ease;
+}
+
+.filed-link:hover,
+.filed-link:focus-visible {
+  background: rgba(37, 99, 235, 0.25);
+}
+
+.filed-link[hidden] {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  header {
+    gap: 1rem;
+  }
+
+  th,
+  td {
+    padding: 0.75rem 0.9rem;
+  }
+
+  .summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- fetch Senate and House periodic transaction reports and add filtering by chamber, transaction type, and activity window
- upgrade the table experience with richer politician metadata, asset details, filing links, and a summary panel
- document the disclosure data pipeline and usage instructions for the updated app

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4dbc5ff2c832bababb2115ba446ca